### PR TITLE
compiler,exec: update for new wagon/wasm API

### DIFF
--- a/compiler/module.go
+++ b/compiler/module.go
@@ -112,7 +112,7 @@ func (m *Module) CompileForInterpreter() (_retCode []InterpreterCode, retErr err
 	if m.Base.Import != nil {
 		for i := 0; i < len(m.Base.Import.Entries); i++ {
 			e := &m.Base.Import.Entries[i]
-			if e.Kind != wasm.ExternalFunction {
+			if e.Type.Kind() != wasm.ExternalFunction {
 				continue
 			}
 			tyID := e.Type.(wasm.FuncImport).Type

--- a/exec/vm.go
+++ b/exec/vm.go
@@ -110,7 +110,7 @@ func NewVirtualMachine(
 
 	if m.Base.Import != nil && impResolver != nil {
 		for _, imp := range m.Base.Import.Entries {
-			switch imp.Kind {
+			switch imp.Type.Kind() {
 			case wasm.ExternalFunction:
 				funcImports = append(funcImports, impResolver.ResolveFunc(imp.ModuleName, imp.FieldName))
 			case wasm.ExternalGlobal:
@@ -144,7 +144,7 @@ func NewVirtualMachine(
 					},
 				}
 			default:
-				panic(fmt.Errorf("import kind not supported: %d", imp.Kind))
+				panic(fmt.Errorf("import kind not supported: %d", imp.Type.Kind()))
 			}
 		}
 	}


### PR DESCRIPTION
go-interpreter/wagon#75 introduced a breaking API change.
This CL adapts life to this new API.