### PR TITLE
all: Update to latest version of wagon

### DIFF
--- a/compiler/module.go
+++ b/compiler/module.go
@@ -42,9 +42,9 @@ func LoadModule(raw []byte) (*Module, error) {
 
 	functionNames := make(map[int]string)
 
-	for _, sec := range m.Other {
+	for _, sec := range m.Customs {
 		if sec.Name == "name" {
-			r := bytes.NewReader(sec.Bytes)
+			r := bytes.NewReader(sec.RawSection.Bytes)
 			for {
 				ty, err := leb128.ReadVarUint32(r)
 				if err != nil || ty != 1 {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/perlin-network/life
 
-replace github.com/go-interpreter/wagon v0.0.0-20180807160906-16de22136ff5 => github.com/losfair/wagon v0.0.0-20180807163237-f6497f251c75
-
-require github.com/go-interpreter/wagon v0.0.0-20180807160906-16de22136ff5
+require github.com/go-interpreter/wagon v0.3.1-0.20180808120418-876a973424d4


### PR DESCRIPTION
Fixes #24
- wagon now supports go modules
- wagon added Customs field to wasm.Module
and removed the Other field

Signed-off-by: Gari Singh <garis@us.ibm.com>