### PR TITLE
Fix import indices

### DIFF
--- a/compiler/module.go
+++ b/compiler/module.go
@@ -110,6 +110,7 @@ func (m *Module) CompileForInterpreter(gp GasPolicy) (_retCode []InterpreterCode
 	importTypeIDs := make([]int, 0)
 
 	if m.Base.Import != nil {
+		j := 0
 		for i := 0; i < len(m.Base.Import.Entries); i++ {
 			e := &m.Base.Import.Entries[i]
 			if e.Type.Kind() != wasm.ExternalFunction {
@@ -122,7 +123,7 @@ func (m *Module) CompileForInterpreter(gp GasPolicy) (_retCode []InterpreterCode
 
 			binary.Write(buf, binary.LittleEndian, uint32(1)) // value ID
 			binary.Write(buf, binary.LittleEndian, opcodes.InvokeImport)
-			binary.Write(buf, binary.LittleEndian, uint32(i))
+			binary.Write(buf, binary.LittleEndian, uint32(j))
 
 			binary.Write(buf, binary.LittleEndian, uint32(0))
 			if len(ty.ReturnTypes) != 0 {
@@ -142,6 +143,7 @@ func (m *Module) CompileForInterpreter(gp GasPolicy) (_retCode []InterpreterCode
 				Bytes:      code,
 			})
 			importTypeIDs = append(importTypeIDs, int(tyID))
+			j++
 		}
 	}
 


### PR DESCRIPTION
The compiler skips over non-function imports, but still uses their presence as part of the index for the function imports.
The VM stores function imports in their own array, so their indices should be only based on themselves.