### PR TITLE
Supporting user-defined parameters for entry point in life.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ python3 run_spec_tests.py /path/to/testsuite
 go build
 
 # run your wasm program
-./life /path/to/your/wasm/program.wasm # entry point is `app_main` with no arguments by default
+# entry point is `app_main` by default if entry flag is omitted, array with 
+# param in it is optional arguements for entrypoint. params should be converted into `int`.
+./life -entry 'method' /path/to/your/wasm/program.wasm [param,...] 
+
 ```
 
 ## Executing WebAssembly Modules

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/perlin-network/life/exec"
 	"io/ioutil"
+	"strconv"
 	"time"
 )
 
@@ -97,9 +98,18 @@ func main() {
 			panic(err)
 		}
 	}
+	var args []int64
+	for _, arg := range flag.Args()[1:] {
+		fmt.Println(arg)
+		if ia, err := strconv.Atoi(arg); err != nil {
+			panic(err)
+		} else {
+			args = append(args, int64(ia))
+		}
+	}
 
 	// Run the WebAssembly module's entry function.
-	ret, err := vm.Run(entryID)
+	ret, err := vm.Run(entryID, args...)
 	if err != nil {
 		vm.PrintStackTrace()
 		panic(err)


### PR DESCRIPTION
 When I used life to run an example translated into wast format for pretty display below,
```
(module
  (func $add (param $lhs i32) (param $rhs i32) (result i32)
    (local i32)
    get_local $lhs
    get_local $rhs
    i32.add
    )
  (export "add" (func $add))
)
```
the `add` entrypoint need 2 parameters, but we can't use life cli to pass it. So I pushed this PR. 