### PR TITLE
exec: remove this printf debugging

### DIFF
--- a/exec/vm.go
+++ b/exec/vm.go
@@ -1562,10 +1562,6 @@ func (vm *VirtualMachine) Execute() {
 			frame.IP += 16
 
 			effective := int(uint64(base) + uint64(offset))
-			fmt.Println("effective:", effective)
-			fmt.Println("mem size:", len(vm.Memory))
-			fmt.Println("base:", base)
-			fmt.Println("offset:", offset)
 			LE.PutUint32(vm.Memory[effective:effective+4], uint32(value))
 		case opcodes.I64Store:
 			LE.Uint32(frame.Code[frame.IP : frame.IP+4])


### PR DESCRIPTION
Makes it difficult to test things with this here:

```
~/g/s/g/Xe/olin/cwa/bin:master* λ cwa -polymerase shaman.wasm 
[Polymerase] Compilation started.
[Polymerase] Compilation finished successfully in 1.937721818s.
effective: 1065360
mem size: 1114112
base: 0
offset: 1065360
effective: 1065356
mem size: 1114112
base: 0
offset: 1065356
effective: 1065352
mem size: 1114112
base: 0
offset: 1065352
<other output>
```