### PR TITLE
Wagon update / Introducing Module to incur compilation once for several virtual machines (multi-threaded scenario)

### DIFF
--- a/compiler/ngen.go
+++ b/compiler/ngen.go
@@ -647,13 +647,13 @@ func (c *SSAFunctionCompiler) NGen(selfID uint64, numParams uint64, numLocals ui
 		case "i64.store", "f64.store":
 			writeMemStore(body, ins, "uint64_t")
 
-		case "current_memory":
+		case "memory.size":
 			bSprintf(body,
 				"%s%d.vu64 = vm->mem_size / 65536;",
 				NGEN_VALUE_PREFIX, ins.Target,
 			)
 
-		case "grow_memory":
+		case "memory.grow":
 			bSprintf(body,
 				"%s%d.vu64 = vm->mem_size / 65536; vm->grow_memory(vm, %s%d.vu32 * 65536);",
 				NGEN_VALUE_PREFIX, ins.Target,

--- a/compiler/serialize.go
+++ b/compiler/serialize.go
@@ -722,10 +722,10 @@ func (c *SSAFunctionCompiler) Serialize() []byte {
 				binary.Write(buf, binary.LittleEndian, uint32(v))
 			}
 
-		case "current_memory":
+		case "memory.size":
 			binary.Write(buf, binary.LittleEndian, opcodes.CurrentMemory)
 
-		case "grow_memory":
+		case "memory.grow":
 			binary.Write(buf, binary.LittleEndian, opcodes.GrowMemory)
 			binary.Write(buf, binary.LittleEndian, uint32(ins.Values[0]))
 

--- a/compiler/ssa.go
+++ b/compiler/ssa.go
@@ -2,12 +2,11 @@ package compiler
 
 import (
 	"fmt"
-
 	"math"
+	"strings"
 
 	"github.com/go-interpreter/wagon/disasm"
 	"github.com/go-interpreter/wagon/wasm"
-	"strings"
 )
 
 type TyValueID uint64
@@ -267,14 +266,14 @@ func (c *SSAFunctionCompiler) Compile(importTypeIDs []int) {
 			c.Locations = append(c.Locations, &Location{
 				CodePos:     len(c.Code),
 				StackDepth:  len(c.Stack),
-				PreserveTop: ins.Block.Signature != wasm.BlockTypeEmpty,
+				PreserveTop: ins.Block != nil && ins.Block.Signature != wasm.BlockTypeEmpty,
 			})
 
 		case "loop":
 			c.Locations = append(c.Locations, &Location{
 				CodePos:         len(c.Code),
 				StackDepth:      len(c.Stack),
-				LoopPreserveTop: ins.Block.Signature != wasm.BlockTypeEmpty,
+				LoopPreserveTop: ins.Block != nil && ins.Block.Signature != wasm.BlockTypeEmpty,
 				BrHead:          true,
 			})
 
@@ -284,7 +283,7 @@ func (c *SSAFunctionCompiler) Compile(importTypeIDs []int) {
 			c.Locations = append(c.Locations, &Location{
 				CodePos:     len(c.Code),
 				StackDepth:  len(c.Stack),
-				PreserveTop: ins.Block.Signature != wasm.BlockTypeEmpty,
+				PreserveTop: ins.Block != nil && ins.Block.Signature != wasm.BlockTypeEmpty,
 				IfBlock:     true,
 			})
 
@@ -442,12 +441,12 @@ func (c *SSAFunctionCompiler) Compile(importTypeIDs []int) {
 				c.PushStack(targetValueID)
 			}
 
-		case "current_memory":
+		case "memory.size":
 			retID := c.NextValueID()
 			c.Code = append(c.Code, buildInstr(retID, ins.Op.Name, nil, nil))
 			c.PushStack(retID)
 
-		case "grow_memory":
+		case "memory.grow":
 			retID := c.NextValueID()
 			c.Code = append(c.Code, buildInstr(retID, ins.Op.Name, nil, c.PopStack(1)))
 			c.PushStack(retID)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/perlin-network/life
 
-replace github.com/go-interpreter/wagon v0.0.0 => github.com/perlin-network/wagon v0.3.1-0.20180825141017-f8cb99b55a39
-
 require (
-	github.com/go-interpreter/wagon v0.0.0
+	github.com/go-interpreter/wagon v0.4.0
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e // indirect
+	google.golang.org/appengine v1.6.0 // indirect
 )

--- a/platform/aot_android_arm.go
+++ b/platform/aot_android_arm.go
@@ -7,6 +7,9 @@ import (
 type AOTContext struct {
 }
 
+func (c *AOTContext) Initialize(vm *exec.VirtualMachine) {
+}
+
 func (c *AOTContext) UnsafeInvokeFunction_0(vm *exec.VirtualMachine, name string) uint64 {
 	return 0
 }

--- a/platform/aot_unix.go
+++ b/platform/aot_unix.go
@@ -81,7 +81,6 @@ static uint64_t unsafe_invoke_function_2(struct VirtualMachine *vm, void *sym, u
 import "C"
 
 import (
-	"github.com/perlin-network/life/exec"
 	"io/ioutil"
 	"log"
 	os_exec "os/exec"
@@ -89,6 +88,8 @@ import (
 	"reflect"
 	"runtime"
 	"unsafe"
+
+	"github.com/perlin-network/life/exec"
 )
 
 //export go_vm_throw_s
@@ -159,6 +160,18 @@ func (c *AOTContext) resolveNameForInvocation(name string) unsafe.Pointer {
 	return sym
 }
 
+func (c *AOTContext) Initialize(vm *exec.VirtualMachine) {
+	nativeVM := C.vm_alloc()
+	C.vm_build(nativeVM, C.uintptr_t(uintptr(unsafe.Pointer(vm))), C.uint64_t(len(vm.Memory)))
+	if len(vm.Memory) > 0 {
+		C.memcpy(unsafe.Pointer(nativeVM.mem), unsafe.Pointer(&vm.Memory[0]), C.ulong(len(vm.Memory)))
+	}
+
+	updateMemory(nativeVM)
+
+	c.vmHandle = nativeVM
+}
+
 func (c *AOTContext) UnsafeInvokeFunction_0(vm *exec.VirtualMachine, name string) uint64 {
 	return uint64(C.unsafe_invoke_function_0(
 		c.vmHandle,
@@ -223,23 +236,71 @@ func FullAOTCompile(vm *exec.VirtualMachine) *AOTContext {
 		return nil
 	}
 
-	nativeVM := C.vm_alloc()
-	C.vm_build(nativeVM, C.uintptr_t(uintptr(unsafe.Pointer(vm))), C.uint64_t(len(vm.Memory)))
-	if len(vm.Memory) > 0 {
-		C.memcpy(unsafe.Pointer(nativeVM.mem), unsafe.Pointer(&vm.Memory[0]), C.ulong(len(vm.Memory)))
-	}
-
-	updateMemory(nativeVM)
-
 	ctx := &AOTContext{
 		dlHandle: handle,
-		vmHandle: nativeVM,
 	}
 
 	runtime.SetFinalizer(ctx, func(ctx *AOTContext) {
 		C.dlclose(ctx.dlHandle)
-		C.vm_destroy(ctx.vmHandle)
-		C.free(unsafe.Pointer(ctx.vmHandle))
+		if ctx.vmHandle != nil {
+			C.vm_destroy(ctx.vmHandle)
+			C.free(unsafe.Pointer(ctx.vmHandle))
+		}
+	})
+
+	return ctx
+}
+
+func FullAOTCompileModule(m *exec.Module) *AOTContext {
+	code := m.NCompile(exec.NCompileConfig{
+		AliasDef:             false,
+		DisableMemBoundCheck: C.need_mem_bound_check() == 0,
+	})
+	tempDir, err := ioutil.TempDir("", "life-aot-")
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	inPath := path.Join(tempDir, "in.c")
+	outPath := path.Join(tempDir, "out")
+
+	err = ioutil.WriteFile(inPath, []byte(code), 0644)
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	cmd := os_exec.Command("clang", "-fPIC", "-O2", "-lm", "-o", outPath, "-shared", inPath)
+	out, err := cmd.CombinedOutput()
+
+	if len(out) > 0 {
+		log.Printf("compiler warnings/errors: \n%s\n", string(out))
+	}
+
+	if err != nil {
+		log.Println(err)
+		return nil
+	}
+
+	outPathC := C.CString(outPath)
+	handle := C.dlopen(outPathC, C.RTLD_NOW|C.RTLD_LOCAL)
+	C.free(unsafe.Pointer(outPathC))
+	if handle == nil {
+		log.Println("unable to open compiled code: " + C.GoString(C.dlerror()))
+		return nil
+	}
+
+	ctx := &AOTContext{
+		dlHandle: handle,
+	}
+
+	runtime.SetFinalizer(ctx, func(ctx *AOTContext) {
+		C.dlclose(ctx.dlHandle)
+		if ctx.vmHandle != nil {
+			C.vm_destroy(ctx.vmHandle)
+			C.free(unsafe.Pointer(ctx.vmHandle))
+		}
 	})
 
 	return ctx

--- a/platform/aot_windows.go
+++ b/platform/aot_windows.go
@@ -7,6 +7,9 @@ import (
 type AOTContext struct {
 }
 
+func (c *AOTContext) Initialize(vm *exec.VirtualMachine) {
+}
+
 func (c *AOTContext) UnsafeInvokeFunction_0(vm *exec.VirtualMachine, name string) uint64 {
 	return 0
 }


### PR DESCRIPTION
I was testing various WebAssembly runtimes [here](https://github.com/pkedy/wasmtest) including Life.  I could not use `life` and `wagon` together in the same project so I decided to attempt to get `life` to support the latest version of `wagon` (v0.4.0).  In my limited testing, it seems to work.

For my use case, I'll be using a pool of Virtual Machines backed by the same WebAssembly module.  I created an alternative struct called `Module` that can be used to read/parse/compile the module once, and then create several virtual machines used by concurrent go routines if desired.

I'm not sure how aligned these changes are with the project's vision/roadmap, but I thought I'd share them.