### PR TITLE
Add Makefile to build tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage.txt
 *.test
 
 go.sum
+test_runner
+tests/generated
+target/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testsuite"]
+	path = testsuite
+	url = git@github.com:WebAssembly/testsuite.git

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+JSON_DIR:=tests/generated
+WAST_DIR:=testsuite
+NO_TEST:=tests/skipped/%.no-test
+TEST_RUNNER:=target/test_runner
+
+# Run all test fixtures
+.PHONY: test
+test: testsuite test_runner wast $(patsubst ${JSON_DIR}/%.json, ${NO_TEST}, $(wildcard ${JSON_DIR}/*.json))
+
+target/test_runner:
+	go build -o ${TEST_RUNNER} ./spec/test_runner
+
+# Pseudo target to run each test fixture
+${NO_TEST}: ${JSON_DIR}/%.json
+	${TEST_RUNNER} $<
+
+# Get latest test suite as a git submodule
+.PHONY: testsuite
+testsuite:
+	git submodule update --init testsuite
+
+# Build all JSON specs
+.PHONY: wast
+wast: $(patsubst ${WAST_DIR}/%.wast, ${JSON_DIR}/%.json, $(wildcard ${WAST_DIR}/*.wast))
+
+# Build JSON specs - requires the wast2json binary to be on PATH, from wabt (https://github.com/WebAssembly/wabt)
+${JSON_DIR}/%.json: testsuite/%.wast
+	wast2json $< -o $@
+
+

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
 	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e // indirect
 )
+
+go 1.13

--- a/tests/skipped/data.no-test
+++ b/tests/skipped/data.no-test
@@ -1,0 +1,1 @@
+This file indicates that the corresponding JSON test in tests/generated is not yet passing and will be excluded. Remove this file to include the test.

--- a/tests/skipped/elem.no-test
+++ b/tests/skipped/elem.no-test
@@ -1,0 +1,1 @@
+This file indicates that the corresponding JSON test in tests/generated is not yet passing and will be excluded. Remove this file to include the test.

--- a/tests/skipped/imports.no-test
+++ b/tests/skipped/imports.no-test
@@ -1,0 +1,1 @@
+This file indicates that the corresponding JSON test in tests/generated is not yet passing and will be excluded. Remove this file to include the test.

--- a/tests/skipped/linking.no-test
+++ b/tests/skipped/linking.no-test
@@ -1,0 +1,1 @@
+This file indicates that the corresponding JSON test in tests/generated is not yet passing and will be excluded. Remove this file to include the test.

--- a/tests/skipped/start.no-test
+++ b/tests/skipped/start.no-test
@@ -1,0 +1,1 @@
+This file indicates that the corresponding JSON test in tests/generated is not yet passing and will be excluded. Remove this file to include the test.


### PR DESCRIPTION
It was not quick and easy for me to see if tests had broken. I think a Makefile is a better lowest common denominator for Go and pulling dependencies rather than the python script. It wasn't clear initially where I should get test suite.

I also think it would be good to have some tests run in CI, you could use github actions, but having a makefile to centralise the logic is a pattern that works well for me.
