### PR TITLE
Fixed code that was silently ignoring pancis

### DIFF
--- a/compiler/module.go
+++ b/compiler/module.go
@@ -288,5 +288,5 @@ func (m *Module) CompileForInterpreter(gp GasPolicy) (ret []InterpreterCode, ret
 			Bytes:      compiler.Serialize(),
 		}
 	}
-	return
+	return ret, retErr
 }

--- a/compiler/module.go
+++ b/compiler/module.go
@@ -114,12 +114,7 @@ func LoadModule(raw []byte) (*Module, error) {
 	}, nil
 }
 
-func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (string, error) {
-	var (
-		out    string
-		retErr error
-	)
-
+func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (out string, retErr error) {
 	defer utils.CatchPanic(&retErr)
 
 	importStubBuilder := &strings.Builder{}
@@ -203,12 +198,7 @@ func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (string, error
 	return out, retErr
 }
 
-func (m *Module) CompileForInterpreter(gp GasPolicy) ([]InterpreterCode, error) {
-	var (
-		ret    []InterpreterCode
-		retErr error
-	)
-
+func (m *Module) CompileForInterpreter(gp GasPolicy) (ret []InterpreterCode, retErr error) {
 	defer utils.CatchPanic(&retErr)
 
 	importTypeIDs := make([]int, 0)
@@ -298,6 +288,5 @@ func (m *Module) CompileForInterpreter(gp GasPolicy) ([]InterpreterCode, error) 
 			Bytes:      compiler.Serialize(),
 		}
 	}
-
-	return ret, retErr
+	return
 }


### PR DESCRIPTION
A return statement defined within the function body is not executed during panic handling, so the value of retError variable defined within the body is ignored leading to silent drop of the panic within the function body. 