### PR TITLE
fixbug: get wrong result when execute opcodes.F64ConvertSI32 & opcodes.F64ConvertUI32

### DIFF
--- a/exec/vm.go
+++ b/exec/vm.go
@@ -1461,12 +1461,12 @@ func (vm *VirtualMachine) Execute() {
 		case opcodes.F64ConvertSI32:
 			v := int32(frame.Regs[int(LE.Uint32(frame.Code[frame.IP:frame.IP+4]))])
 			frame.IP += 4
-			frame.Regs[valueID] = int64(int32(math.Float64bits(float64(v))))
+			frame.Regs[valueID] = int64(math.Float64bits(float64(v)))
 
 		case opcodes.F64ConvertUI32:
 			v := uint32(frame.Regs[int(LE.Uint32(frame.Code[frame.IP:frame.IP+4]))])
 			frame.IP += 4
-			frame.Regs[valueID] = int64(int32(math.Float64bits(float64(v))))
+			frame.Regs[valueID] = int64(math.Float64bits(float64(v)))
 
 		case opcodes.F64ConvertSI64:
 			v := int64(frame.Regs[int(LE.Uint32(frame.Code[frame.IP:frame.IP+4]))])


### PR DESCRIPTION
fixbug: get wrong result when execute opcodes.F64ConvertSI32 & opcodes.F64ConvertUI32