### PR TITLE
Let host functions halt the VM

### DIFF
--- a/exec/vm.go
+++ b/exec/vm.go
@@ -369,7 +369,7 @@ func (vm *VirtualMachine) Execute() {
 
 	frame := vm.GetCurrentFrame()
 
-	for {
+	for !vm.Exited {
 		valueID := int(LE.Uint32(frame.Code[frame.IP : frame.IP+4]))
 		ins := opcodes.Opcode(frame.Code[frame.IP+4])
 		frame.IP += 5


### PR DESCRIPTION
This is a minor tweak to allow the VM to be halted by host functions. This is e.g. useful if the halting condition is decided in an event handler that is polled by the WASM code.

Such a function simply needs to set `vm.Exited = true`.