### PR TITLE
compiler/module: Catch panics properly.

### DIFF
--- a/compiler/module.go
+++ b/compiler/module.go
@@ -114,12 +114,7 @@ func LoadModule(raw []byte) (*Module, error) {
 	}, nil
 }
 
-func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (string, error) {
-	var (
-		out    string
-		retErr error
-	)
-
+func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (out string, retErr error) {
 	defer utils.CatchPanic(&retErr)
 
 	importStubBuilder := &strings.Builder{}
@@ -203,12 +198,7 @@ func (m *Module) CompileWithNGen(gp GasPolicy, numGlobals uint64) (string, error
 	return out, retErr
 }
 
-func (m *Module) CompileForInterpreter(gp GasPolicy) ([]InterpreterCode, error) {
-	var (
-		ret    []InterpreterCode
-		retErr error
-	)
-
+func (m *Module) CompileForInterpreter(gp GasPolicy) (ret []InterpreterCode, retErr error) {
 	defer utils.CatchPanic(&retErr)
 
 	importTypeIDs := make([]int, 0)


### PR DESCRIPTION
Currently, if a compiler panics, the error is recorded into a local
variable defined in the scope of a Compile* function.  This variable
however has no direct relation to the return value of the function.
So if a panic actually happens, the last `return` statement is not
executed and the function just returns empty default values.

This behaviour results in errors being silently discurded, the
concequences of such errors are typically discovered much later during
execution (e.g., as index out of bounds panics in vm.go).

After this change, panics in Compile* functions are always propagated
to the caller as errors.